### PR TITLE
chore(ci): atualiza actions para suporte ao Node.js 24

### DIFF
--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -8,17 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: wrapper
 


### PR DESCRIPTION
### Contexto:

A esteira de integração contínua (CI) passou a exibir warnings alertando que o ambiente Node.js 20 será descontinuado em junho de 2026. Este PR é uma manutenção preventiva para garantir a estabilidade do build.

#### O que foi alterado:

No arquivo `.github/workflows/build-and-tests.yml`:

-  `actions/checkout` atualizado para v5.
-  `actions/setup-java` atualizado para v5.
-  `gradle/actions/setup-gradle` atualizado para v4.